### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+


### PR DESCRIPTION
View the code from Github with the default tab space (8 chars) ir really a mess... With this all the tabs will be translated to 4 chars on github :)