### PR TITLE
Initialize Strings before classes are defined

### DIFF
--- a/jtransc-rt/resources/cpp/Base.cpp
+++ b/jtransc-rt/resources/cpp/Base.cpp
@@ -187,6 +187,10 @@ struct N { public:
 };
 
 
+// Strings
+{{ STRINGS }}
+
+
 /// ARRAY_HEADERS
 
 {{ ARRAY_HEADERS_PRE }}
@@ -354,8 +358,6 @@ SOBJ JA_0::toDoubleArray() { return SOBJ(new JA_D((void *)getStartPtr(), bytesLe
 
 {{ ARRAY_HEADERS_POST }}
 
-// Strings
-{{ STRINGS }}
 
 // Classes IMPLS
 {{ CLASSES_IMPL }}


### PR DESCRIPTION
This is necessary, because classes could refer to string literals
before they were defined.