### PR TITLE
Fix adding extra variables from gradle that do not have a matching already defined program annotation

### DIFF
--- a/jtransc-core/src/com/jtransc/gen/common/CommonGenerator.kt
+++ b/jtransc-core/src/com/jtransc/gen/common/CommonGenerator.kt
@@ -18,9 +18,11 @@ import com.jtransc.gen.MinimizedNames
 import com.jtransc.gen.TargetName
 import com.jtransc.injector.Injector
 import com.jtransc.io.ProcessResult2
+import com.jtransc.json.Json
 import com.jtransc.lang.high
 import com.jtransc.lang.low
 import com.jtransc.lang.putIfAbsentJre7
+import com.jtransc.log.log
 import com.jtransc.plugin.JTranscPluginGroup
 import com.jtransc.template.Minitemplate
 import com.jtransc.text.Indenter
@@ -1729,7 +1731,7 @@ abstract class CommonGenerator(val injector: Injector) : IProgramTemplate {
 
 	@Suppress("ConvertLambdaToReference")
 	val params by lazy {
-		(
+		val result = (
 			mapOf(
 				"CLASS" to "",
 				"outputFolder" to outputFile2.parent,
@@ -1767,7 +1769,13 @@ abstract class CommonGenerator(val injector: Injector) : IProgramTemplate {
 			) + extraVars
 			)
 			.toHashMap()
+		log.info("TEMPLATE VARS:")
+		log.info(Json.encode(result))
+		log.info("extraVars:")
+		log.info(Json.encode(extraVars))
+		result
 	}
+
 
 	open fun setTemplateParamsAfterBuildingSource() {
 		params["entryPointFile"] = entryPointFilePath

--- a/jtransc-utils/src/com/jtransc/ds/MapExt.kt
+++ b/jtransc-utils/src/com/jtransc/ds/MapExt.kt
@@ -4,3 +4,9 @@ inline fun <T1, T2> MutableMap<T1, T2>.getOrPut2(key: T1, generator: () -> T2): 
 	if (key !in this) this[key] = generator()
 	return this[key]!!
 }
+
+fun <K, V> Map<K, Iterable<V>>.combinedWith(that: Map<K, Iterable<V>>): Map<K, List<V>> {
+	return (this.keys + that.keys).distinct()
+		.map { it to (this[it] ?: listOf()) + (that[it] ?: listOf()) }
+		.toMap()
+}

--- a/jtransc-utils/src/com/jtransc/json/writer.kt
+++ b/jtransc-utils/src/com/jtransc/json/writer.kt
@@ -39,7 +39,7 @@ fun JsonWriter.writeValue(value: Any?): JsonWriter = this.apply {
 		is String -> writeString(value)
 		is Double -> writeNumber(value)
 		is Number -> writeNumber(value.toDouble())
-		else -> throw JsonWriterException("Don't know how to serialize $value")
+		else -> writeObject(com.jtransc.lang.Dynamic.toMap(value))
 	}
 }
 

--- a/jtransc-utils/test/com/jtransc/lang/MapExtKtTest.kt
+++ b/jtransc-utils/test/com/jtransc/lang/MapExtKtTest.kt
@@ -1,5 +1,6 @@
 package com.jtransc.lang
 
+import com.jtransc.ds.combinedWith
 import org.junit.Assert.*
 import org.junit.Test
 
@@ -12,6 +13,18 @@ class MapExtKtTest {
 		assertEquals(
 			mapOf("a" to listOf(1, 2, 3, 4, 5), "b" to listOf(3), "c" to listOf()),
 			map1.mergeMapListWith(map2)
+		)
+	}
+
+	@Test
+	fun combinedWith() {
+		val res = mapOf("l" to listOf(1, 2, 3), "m" to listOf(4))
+			.combinedWith(
+				mapOf("m" to listOf(5, 6), "m" to listOf(5), "r" to listOf(7, 8))
+			)
+		assertEquals(
+			mapOf("l" to listOf(1, 2, 3), "m" to listOf(4, 5), "r" to listOf(7, 8)),
+			res
 		)
 	}
 }


### PR DESCRIPTION
The problem was that it was merging extra variables using as reference variables from annotations. So if when key existed in gradle but not in annotations, it didn't work.

Should fix: https://github.com/jtransc/gdx-backend-jtransc/issues/60