### PR TITLE
Add pthread library in CMakeLists.txt

### DIFF
--- a/jtransc-rt/resources/cpp/CMakeLists.txt
+++ b/jtransc-rt/resources/cpp/CMakeLists.txt
@@ -42,5 +42,5 @@ ENDIF()
 add_executable(program program.cpp)
 
 {% for lib in CPP_LIBS %}
-target_link_libraries(program {{ lib }})
+target_link_libraries(program pthread {{ lib }})
 {% end %}


### PR DESCRIPTION
Add this to avoid linking error on Linux. (At least Bash on WIndows)
But I am not very sure whether it will affect other platforms since my Windows plain cpp build is broken...