### PR TITLE
Haxelib quiet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ before_script:
 - export NEKOPATH=$PWD/neko-2.1.0-linux64
 - export HAXEPATH=$PWD/haxe-3.4.2
 - export PATH=$HAXEPATH:$NEKOPATH:$PATH
-- haxelib --always setup $HAXELIB_PATH
-- haxelib --always install hxcpp
+- haxelib --quiet --always setup $HAXELIB_PATH
+- haxelib --quiet --always install hxcpp
 - ls -la $PWD
 - ls -la $PWD/haxe-3.4.2
 - g++ --version || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_script:
 - export HAXEPATH=$PWD/haxe-3.4.2
 - export PATH=$HAXEPATH:$NEKOPATH:$PATH
 - haxelib --quiet --always setup $HAXELIB_PATH
-- haxelib --quiet --always install hxcpp
+- haxelib --quiet --always install hxcpp > /dev/null
 - ls -la $PWD
 - ls -la $PWD/haxe-3.4.2
 - g++ --version || true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,9 @@ install:
   - cmd: cinst -y dmd --version=2.073.0 || ver>nul
   - cmd: cinst -y dart-sdk --version=1.24.2 || ver>nul # See https://chocolatey.org/packages/KB3035131#comment-3325263191
   - cmd: SET NEKOPATH=C:\ProgramData\chocolatey\lib\neko
-  - cmd: haxelib --always setup C:\Users\appveyor\haxelib
-  - cmd: haxelib --always install lime 5.3.0
-  - cmd: haxelib --always run lime setup
+  - cmd: haxelib --quiet --always setup C:\Users\appveyor\haxelib
+  - cmd: haxelib --quiet --always install lime 5.3.0
+  - cmd: haxelib --quiet --always run lime setup
   - cmd: copy c:\tools\php71\php.ini-production c:\tools\php71\php.ini /Y
   - cmd: echo date.timezone="UTC" >> c:\tools\php71\php.ini
   - cmd: echo extension_dir=ext >> c:\tools\php71\php.ini


### PR DESCRIPTION
Hopefully prevent filling travis log with nonsense:
```
Downloading hxcpp-3,4,64.zip...
1024/48635729 (0%)
2048/48635729 (0%)
...
7168/48635729 (0%)
8192/48635729 (0%)
9216/48635729 (0%)
```

80% of the log, which makes checking travis log much slower