### PR TITLE
Try to fix haxecpp travis tests

### DIFF
--- a/jtransc-rt/resources/hx/JA_B.hx
+++ b/jtransc-rt/resources/hx/JA_B.hx
@@ -91,7 +91,7 @@ class JA_B extends JA_0 {
 	{{ HAXE_METHOD_ANNOTATIONS }}
     static public function copy(from:JA_B, to:JA_B, fromPos:Int, toPos:Int, length:Int) {
     	#if cpp
-    	to.data.blit(toPos, from.data, fromPos, length);
+    	to.data.blit(toPos, from.data, fromPos, length); // does this support overlapping?
     	#else
     	if (from == to && toPos > fromPos) {
 			var n = length;

--- a/jtransc-rt/resources/hx/JA_B.hx
+++ b/jtransc-rt/resources/hx/JA_B.hx
@@ -90,16 +90,16 @@ class JA_B extends JA_0 {
 
 	{{ HAXE_METHOD_ANNOTATIONS }}
     static public function copy(from:JA_B, to:JA_B, fromPos:Int, toPos:Int, length:Int) {
-    	#if cpp
-    	to.data.blit(toPos, from.data, fromPos, length); // does this support overlapping?
-    	#else
+    	//#if cpp
+    	//to.data.blit(toPos, from.data, fromPos, length); // does this support overlapping?
+    	//#else
     	if (from == to && toPos > fromPos) {
 			var n = length;
 			while (--n >= 0) to.set(toPos + n, from.get(fromPos + n));
     	} else {
 	        for (n in 0 ... length) to.set(toPos + n, from.get(fromPos + n));
 		}
-		#end
+		//#end
     }
 
 	{{ HAXE_METHOD_ANNOTATIONS }}

--- a/jtransc-rt/resources/hx/JA_C.hx
+++ b/jtransc-rt/resources/hx/JA_C.hx
@@ -91,16 +91,16 @@ class JA_C extends JA_0 {
 
 	{{ HAXE_METHOD_ANNOTATIONS }}
     static public function copy(from:JA_C, to:JA_C, fromPos:Int, toPos:Int, length:Int) {
-		#if (cpp || flash)
-		Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
-		#else
+		//#if (cpp || flash)
+		//Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
+		//#else
     	if (from == to && toPos > fromPos) {
 			var n = length;
 			while (--n >= 0) to.set(toPos + n, from.get(fromPos + n));
     	} else {
 	        for (n in 0 ... length) to.set(toPos + n, from.get(fromPos + n));
 		}
-		#end
+		//#end
     }
 
 	{{ HAXE_METHOD_ANNOTATIONS }}

--- a/jtransc-rt/resources/hx/JA_C.hx
+++ b/jtransc-rt/resources/hx/JA_C.hx
@@ -92,7 +92,7 @@ class JA_C extends JA_0 {
 	{{ HAXE_METHOD_ANNOTATIONS }}
     static public function copy(from:JA_C, to:JA_C, fromPos:Int, toPos:Int, length:Int) {
 		#if (cpp || flash)
-		Vector.blit(from.data, fromPos, to.data, toPos, length);
+		Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
 		#else
     	if (from == to && toPos > fromPos) {
 			var n = length;

--- a/jtransc-rt/resources/hx/JA_D.hx
+++ b/jtransc-rt/resources/hx/JA_D.hx
@@ -73,9 +73,9 @@ class JA_D extends JA_0 {
 
 	{{ HAXE_METHOD_ANNOTATIONS }}
     static public function copy(from:JA_D, to:JA_D, fromPos:Int, toPos:Int, length:Int) {
-		#if (sys || flash)
-		Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
-		#else
+		//#if (sys || flash)
+		//Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
+		//#else
 		var _from:Float64Array = from.data;
 		var _to:Float64Array = to.data;
     	if (from == to && toPos > fromPos) {
@@ -84,7 +84,7 @@ class JA_D extends JA_0 {
     	} else {
 	        for (n in 0 ... length) _to[toPos + n] = _from[fromPos + n];
 		}
-		#end
+		//#end
     }
 
 	{{ HAXE_METHOD_ANNOTATIONS }}

--- a/jtransc-rt/resources/hx/JA_D.hx
+++ b/jtransc-rt/resources/hx/JA_D.hx
@@ -74,7 +74,7 @@ class JA_D extends JA_0 {
 	{{ HAXE_METHOD_ANNOTATIONS }}
     static public function copy(from:JA_D, to:JA_D, fromPos:Int, toPos:Int, length:Int) {
 		#if (sys || flash)
-		Vector.blit(from.data, fromPos, to.data, toPos, length);
+		Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
 		#else
 		var _from:Float64Array = from.data;
 		var _to:Float64Array = to.data;

--- a/jtransc-rt/resources/hx/JA_D.hx
+++ b/jtransc-rt/resources/hx/JA_D.hx
@@ -76,13 +76,20 @@ class JA_D extends JA_0 {
 		//#if (sys || flash)
 		//Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
 		//#else
-		var _from:Float64Array = from.data;
-		var _to:Float64Array = to.data;
+		//var _from:Float64Array = from.data;
+		//var _to:Float64Array = to.data;
+    	//if (from == to && toPos > fromPos) {
+		//	var n = length;
+		//	while (--n >= 0) _to[toPos + n] = _from[fromPos + n];
+    	//} else {
+	    //    for (n in 0 ... length) _to[toPos + n] = _from[fromPos + n];
+		//}
+
     	if (from == to && toPos > fromPos) {
 			var n = length;
-			while (--n >= 0) _to[toPos + n] = _from[fromPos + n];
+			while (--n >= 0) to.set(toPos + n, from.get(fromPos + n));
     	} else {
-	        for (n in 0 ... length) _to[toPos + n] = _from[fromPos + n];
+	        for (n in 0 ... length) to.set(toPos + n, from.get(fromPos + n));
 		}
 		//#end
     }

--- a/jtransc-rt/resources/hx/JA_F.hx
+++ b/jtransc-rt/resources/hx/JA_F.hx
@@ -83,7 +83,7 @@ class JA_F extends JA_0 {
 	{{ HAXE_METHOD_ANNOTATIONS }}
     static public function copy(from:JA_F, to:JA_F, fromPos:Int, toPos:Int, length:Int) {
  		#if (cpp || flash)
- 		Vector.blit(from.data, fromPos, to.data, toPos, length);
+ 		Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
  		#else
 	   	if (from == to && toPos > fromPos) {
 			var n = length;

--- a/jtransc-rt/resources/hx/JA_F.hx
+++ b/jtransc-rt/resources/hx/JA_F.hx
@@ -82,16 +82,16 @@ class JA_F extends JA_0 {
 
 	{{ HAXE_METHOD_ANNOTATIONS }}
     static public function copy(from:JA_F, to:JA_F, fromPos:Int, toPos:Int, length:Int) {
- 		#if (cpp || flash)
- 		Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
- 		#else
+ 		//#if (cpp || flash)
+ 		//Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
+ 		//#else
 	   	if (from == to && toPos > fromPos) {
 			var n = length;
 			while (--n >= 0) to.set(toPos + n, from.get(fromPos + n));
     	} else {
 	        for (n in 0 ... length) to.set(toPos + n, from.get(fromPos + n));
 	    }
-	    #end
+	    //#end
     }
 
 	{{ HAXE_METHOD_ANNOTATIONS }}

--- a/jtransc-rt/resources/hx/JA_I.hx
+++ b/jtransc-rt/resources/hx/JA_I.hx
@@ -121,16 +121,16 @@ class JA_I extends JA_0 {
 
 	{{ HAXE_METHOD_ANNOTATIONS }}
     static public function copy(from:JA_I, to:JA_I, fromPos:Int, toPos:Int, length:Int) {
-		#if (cpp || flash)
-		Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
-		#else
+		//#if (cpp || flash)
+		//Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
+		//#else
     	if (from == to && toPos > fromPos) {
 			var n = length;
 			while (--n >= 0) to.set(toPos + n, from.get(fromPos + n));
     	} else {
 	        for (n in 0 ... length) to.set(toPos + n, from.get(fromPos + n));
 	    }
-		#end
+		//#end
     }
 
 	{{ HAXE_METHOD_ANNOTATIONS }}

--- a/jtransc-rt/resources/hx/JA_I.hx
+++ b/jtransc-rt/resources/hx/JA_I.hx
@@ -122,7 +122,7 @@ class JA_I extends JA_0 {
 	{{ HAXE_METHOD_ANNOTATIONS }}
     static public function copy(from:JA_I, to:JA_I, fromPos:Int, toPos:Int, length:Int) {
 		#if (cpp || flash)
-		Vector.blit(from.data, fromPos, to.data, toPos, length);
+		Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
 		#else
     	if (from == to && toPos > fromPos) {
 			var n = length;

--- a/jtransc-rt/resources/hx/JA_J.hx
+++ b/jtransc-rt/resources/hx/JA_J.hx
@@ -89,7 +89,7 @@ class JA_J extends JA_0 {
 	{{ HAXE_METHOD_ANNOTATIONS }}
     public override function clone() {
     	var out = new JA_J(length);
-    	Vector.blit(this.data, 0, out.data, 0, out.data.length);
+    	Vector.blit(this.data, 0, out.data, 0, out.data.length); // does this support overlapping?
     	return out;
 	}
 
@@ -111,7 +111,7 @@ class JA_J extends JA_0 {
     	#end
 
  		#if (cpp || flash)
- 		Vector.blit(from.data, fromPos, to.data, toPos, length);
+ 		Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
  		#else
 	   	if (from == to && toPos > fromPos) {
 			var n = length;

--- a/jtransc-rt/resources/hx/JA_J.hx
+++ b/jtransc-rt/resources/hx/JA_J.hx
@@ -110,16 +110,16 @@ class JA_J extends JA_0 {
     	length *= 2;
     	#end
 
- 		#if (cpp || flash)
- 		Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
- 		#else
+ 		//#if (cpp || flash)
+ 		//Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
+ 		//#else
 	   	if (from == to && toPos > fromPos) {
 			var n = length;
 			while (--n >= 0) to.set(toPos + n, from.get(fromPos + n));
     	} else {
 	        for (n in 0 ... length) to.set(toPos + n, from.get(fromPos + n));
 	    }
-	    #end
+	    //#end
     }
 
 	{{ HAXE_METHOD_ANNOTATIONS }}

--- a/jtransc-rt/resources/hx/JA_L.hx
+++ b/jtransc-rt/resources/hx/JA_L.hx
@@ -92,7 +92,7 @@ class JA_L extends JA_0 {
 	{{ HAXE_METHOD_ANNOTATIONS }}
     static public function copy(from:JA_L, to:JA_L, fromPos:Int, toPos:Int, length:Int) {
 		#if (sys || flash)
-		Vector.blit(from.data, fromPos, to.data, toPos, length);
+		Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
 		#else
     	if (from == to && toPos > fromPos) {
 			var n = length;

--- a/jtransc-rt/resources/hx/JA_L.hx
+++ b/jtransc-rt/resources/hx/JA_L.hx
@@ -91,16 +91,16 @@ class JA_L extends JA_0 {
 
 	{{ HAXE_METHOD_ANNOTATIONS }}
     static public function copy(from:JA_L, to:JA_L, fromPos:Int, toPos:Int, length:Int) {
-		#if (sys || flash)
-		Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
-		#else
+		//#if (sys || flash)
+		//Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
+		//#else
     	if (from == to && toPos > fromPos) {
 			var n = length;
 			while (--n >= 0) to.set(toPos + n, from.get(fromPos + n));
     	} else {
         	for (n in 0 ... length) to.set(toPos + n, from.get(fromPos + n));
 		}
-		#end
+		//#end
     }
 
 	{{ HAXE_METHOD_ANNOTATIONS }}

--- a/jtransc-rt/resources/hx/JA_S.hx
+++ b/jtransc-rt/resources/hx/JA_S.hx
@@ -88,16 +88,16 @@ class JA_S extends JA_0 {
 
 	{{ HAXE_METHOD_ANNOTATIONS }}
     static public function copy(from:JA_S, to:JA_S, fromPos:Int, toPos:Int, length:Int) {
-		#if (cpp || flash)
-		Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
-		#else
+		//#if (cpp || flash)
+		//Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
+		//#else
     	if (from == to && toPos > fromPos) {
 			var n = length;
 			while (--n >= 0) to.set(toPos + n, from.get(fromPos + n));
     	} else {
 	        for (n in 0 ... length) to.set(toPos + n, from.get(fromPos + n));
 	    }
-	    #end
+	    //#end
     }
 
 	{{ HAXE_METHOD_ANNOTATIONS }}

--- a/jtransc-rt/resources/hx/JA_S.hx
+++ b/jtransc-rt/resources/hx/JA_S.hx
@@ -89,7 +89,7 @@ class JA_S extends JA_0 {
 	{{ HAXE_METHOD_ANNOTATIONS }}
     static public function copy(from:JA_S, to:JA_S, fromPos:Int, toPos:Int, length:Int) {
 		#if (cpp || flash)
-		Vector.blit(from.data, fromPos, to.data, toPos, length);
+		Vector.blit(from.data, fromPos, to.data, toPos, length); // does this support overlapping?
 		#else
     	if (from == to && toPos > fromPos) {
 			var n = length;


### PR DESCRIPTION
This PR is to try to find and fix the flacky HaxeCpp big test that seems to be related to copy.
My guess is that Vector.blit doesn't support overlapping that is a property supported by java System.copy.
http://en.cppreference.com/w/c/string/byte/memcpy <--- overlapping produces undefined results for performance
http://en.cppreference.com/w/c/string/byte/memmove <--- overlapping is supported

It seems (at least in theory) that it should support overlapping:
https://github.com/HaxeFoundation/hxcpp/blob/492b0cbb91c5eb0fe6214b3e5f04bf10e1828163/src/Array.cpp#L161