### PR TITLE
Allow to enable/disable JS asynchronous generation

### DIFF
--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,2 +1,2 @@
-.gradle
-build
+/.gradle
+/build

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -32,4 +32,9 @@ dependencies {
 jtransc {
 	minimizeNames = true
 	treeshaking = true
+
+	// Call ./gradlew -Pjs_enable_async=true runJs
+	if (rootProject.findProperty("js_enable_async")?.toString()?.toBoolean() ?: false) {
+		param("js_enable_async", "true")
+	}
 }

--- a/jtransc-core/src/com/jtransc/gen/common/CommonGenerator.kt
+++ b/jtransc-core/src/com/jtransc/gen/common/CommonGenerator.kt
@@ -1788,6 +1788,8 @@ abstract class CommonGenerator(val injector: Injector) : IProgramTemplate {
 ///////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////
 
+	open val targetExtraParams = mapOf<String, Any?>()
+
 	@Suppress("ConvertLambdaToReference")
 	val params by lazy {
 		val result = (
@@ -1826,7 +1828,7 @@ abstract class CommonGenerator(val injector: Injector) : IProgramTemplate {
 				"TARGET_DEFINES" to targetDefines,
 				"JTRANSC_VERSION" to JTranscVersion.getVersion(),
 				"JTRANSC_OS" to JTranscSystem.getOS()
-			) + extraVars
+			) + extraVars + targetExtraParams
 			)
 			.toHashMap()
 		log.info("TEMPLATE VARS:")

--- a/jtransc-gen-common-tests/src/jtransc/ref/MethodBodyReferencesTest.java
+++ b/jtransc-gen-common-tests/src/jtransc/ref/MethodBodyReferencesTest.java
@@ -19,7 +19,7 @@ public class MethodBodyReferencesTest {
 		}
 	}
 
-	@JTranscMethodBody(target = "js", value = "{% SMETHOD jtransc.ref.MethodBodyReferencesTestJs:test %}(_jc);")
+	@JTranscMethodBody(target = "js", value = "{% SMETHOD jtransc.ref.MethodBodyReferencesTestJs:test %}({{ JC }});")
 	@JTranscMethodBody(target = "cpp", value = "{% SMETHOD jtransc.ref.MethodBodyReferencesTestCpp:test %}();")
 	static private void demo() {
 		MethodBodyReferencesTestJvm.test();

--- a/jtransc-gen-js/src/com/jtransc/gen/js/JsTarget.kt
+++ b/jtransc-gen-js/src/com/jtransc/gen/js/JsTarget.kt
@@ -79,7 +79,7 @@ class JsGenerator(injector: Injector) : CommonGenerator(injector) {
 	override val optionalDoubleDummyDecimals = true
 
 	//val IS_ASYNC = false
-	val IS_ASYNC = true
+	val IS_ASYNC = extraParams["js_enable_async"]?.toBoolean() ?: false
 
 	val IS_JC = IS_ASYNC
 

--- a/jtransc-gen-js/src/com/jtransc/gen/js/JsTarget.kt
+++ b/jtransc-gen-js/src/com/jtransc/gen/js/JsTarget.kt
@@ -78,6 +78,26 @@ class JsGenerator(injector: Injector) : CommonGenerator(injector) {
 
 	override val optionalDoubleDummyDecimals = true
 
+	//val IS_ASYNC = false
+	val IS_ASYNC = true
+
+	val IS_JC = IS_ASYNC
+
+	val ASYNC = if (IS_ASYNC) "async " else ""
+	val AWAIT = if (IS_ASYNC) "await" else ""
+	val JC = if (IS_JC) "_jc" else ""
+	val JC_COMMA = if (IS_JC) "_jc, " else ""
+	val JC_LIST = if (IS_JC) listOf("_jc") else listOf()
+
+	override val targetExtraParams = mapOf<String, Any?>(
+		"IS_ASYNC" to IS_ASYNC,
+		"IS_JC" to IS_JC,
+		"JC" to JC,
+		"JC_COMMA" to JC_COMMA,
+		"AWAIT" to AWAIT,
+		"ASYNC" to ASYNC
+	)
+
 	override fun compileAndRun(redirect: Boolean): ProcessResult2 = _compileRun(run = true, redirect = redirect)
 	override fun compile(): ProcessResult2 = _compileRun(run = false, redirect = false)
 
@@ -159,21 +179,19 @@ class JsGenerator(injector: Injector) : CommonGenerator(injector) {
 			for (indent in classesIndenter) line(indent)
 			val mainClassClass = program[mainClassFq]
 
-			line("async function __main()") {
+			line("${ASYNC}function __main()") {
 				line("var _jc = { threadId: 0, global: {} };") // JTransc Context (we can implement threads here)
-				line("await __createJavaArrays();")
-				line("await __buildStrings();")
-				line("await N.preInit(_jc);")
+				line("$AWAIT __createJavaArrays();")
+				line("$AWAIT __buildStrings();")
+				line("$AWAIT N.preInit($JC);")
 				line(genStaticConstructorsSorted())
 				//line(buildStaticInit(mainClassFq))
 				val mainMethod2 = mainClassClass[AstMethodRef(mainClassFq, "main", AstType.METHOD(AstType.VOID, listOf(ARRAY(AstType.STRING))))]
 				val mainCall = buildMethod(mainMethod2, static = true)
 				line("try {")
 				indent {
-					line("await N.afterInit(_jc);")
-					val await = if (mainMethod2.isAsync) "await " else ""
-					line("$await$mainCall(_jc, N.strArray(N.args()));")
-					//line("$mainCall(N.strArray(N.args()));")
+					line("$AWAIT N.afterInit($JC);")
+					line("$AWAIT $mainCall(${JC_COMMA}N.strArray(N.args()));")
 				}
 				line("} catch (e) {")
 				indent {
@@ -182,7 +200,10 @@ class JsGenerator(injector: Injector) : CommonGenerator(injector) {
 				}
 				line("}")
 			}
-			line("__main().catch((e) => { console.error(e); });")
+			line("let result = __main();")
+			if (IS_ASYNC) {
+				line("result.catch((e) => { console.error(e); });")
+			}
 			line(concatFilesTrans.append)
 		}
 
@@ -212,7 +233,7 @@ class JsGenerator(injector: Injector) : CommonGenerator(injector) {
 	}
 
 	override fun genSICall(it: AstClass): String {
-		return "await " + "${it.name.targetNameForStatic}" + access("SI", static = true, field = false) + "(_jc);"
+		return "$AWAIT " + "${it.name.targetNameForStatic}" + access("SI", static = true, field = false) + "($JC);"
 	}
 
 	override fun genStmTryCatch(stm: AstStm.TRY_CATCH) = indent {
@@ -281,9 +302,9 @@ class JsGenerator(injector: Injector) : CommonGenerator(injector) {
 			"box",
 			"boxVoid", "boxBool", "boxByte", "boxShort", "boxChar",
 			"boxInt", "boxLong", "boxFloat", "boxDouble", "boxString", "boxWrapped"
-			-> "N.$name(_jc, $args)"
+			-> "N.$name($JC_COMMA$args)"
 		//"resolveClass", "iteratorToArray", "imap" -> "(await($base))"
-			"iteratorToArray", "imap" -> "(await(_jc, $base))"
+			"iteratorToArray", "imap" -> "($AWAIT($JC_COMMA$base))"
 			else -> base
 		}
 	}
@@ -330,21 +351,21 @@ class JsGenerator(injector: Injector) : CommonGenerator(injector) {
 	override fun genCallWrap(e: AstExpr.CALL_BASE, str: String): String {
 		val callAsync = e.method.actualMethod?.isAsync != false
 		if (callAsync) ensureAsynchronous(e.method.toString())
-		return if (callAsync) "(await($str))" else str
+		return if (callAsync) "($AWAIT($str))" else str
 	}
 
 	override fun generateDeclArgString(args: List<String>): String {
-		return (listOf("_jc") + args).joinToString(", ")
+		return (JC_LIST + args).joinToString(", ")
 	}
 
 	override fun generateCallArgString(args: List<String>, isNativeCall: Boolean): String {
-		return ((if (isNativeCall) listOf() else listOf("_jc")) + args).joinToString(", ")
+		return ((if (isNativeCall) listOf() else JC_LIST) + args).joinToString(", ")
 	}
 
 	override fun genExprCallBaseSuper(e2: AstExpr.CALL_SUPER, clazz: AstType.REF, refMethodClass: AstClass, method: AstMethodRef, methodAccess: String, args: List<String>, isNativeCall: Boolean): String {
 		val superMethod = refMethodClass[method.withoutClass] ?: invalidOp("Can't find super for method : $method")
 		val base = superMethod.containingClass.name.targetName + ".prototype"
-		val argsString = (listOf(e2.obj.genExpr()) + (if (isNativeCall) listOf() else listOf("_jc")) + args).joinToString(", ")
+		val argsString = (listOf(e2.obj.genExpr()) + (if (isNativeCall) listOf() else JC_LIST) + args).joinToString(", ")
 		return genCallWrap(e2, "$base$methodAccess.call($argsString)")
 	}
 
@@ -388,19 +409,19 @@ class JsGenerator(injector: Injector) : CommonGenerator(injector) {
 				}
 
 				if (staticFields.isNotEmpty() || clazz.staticConstructor != null) {
-					line("static async SI(_jc)") {
+					line("static $ASYNC SI($JC)") {
 						//line("$classBase.SI = N.EMPTY_FUNCTION;")
 						for (field in staticFields) {
 							val nativeMemberName = if (field.targetName == field.name) field.name else field.targetName
 							line("$classBase${instanceAccess(nativeMemberName, field = true)} = ${field.escapedConstantValue};")
 						}
 						if (clazz.staticConstructor != null) {
-							val await = if (clazz.staticConstructor?.isAsync == true) "await " else ""
-							line("($await($classBase${getTargetMethodAccess(clazz.staticConstructor!!, true)}(_jc)));")
+							val await = if (clazz.staticConstructor?.isAsync == true) "$AWAIT " else ""
+							line("($await($classBase${getTargetMethodAccess(clazz.staticConstructor!!, true)}($JC)));")
 						}
 					}
 				} else {
-					line("static async SI(_jc)") {
+					line("static $ASYNC SI($JC)") {
 
 					}
 				}
@@ -417,7 +438,7 @@ class JsGenerator(injector: Injector) : CommonGenerator(injector) {
 						//val methodName = if (method.targetName == defaultMethodName) null else method.targetName
 						val nativeMemberName = buildMethod(method, false, includeDot = false)
 						//val prefix = "${getMemberBase(method.isStatic)}${instanceAccess(nativeMemberName, field = false)}"
-						val async = if (method.isAsync) "async " else ""
+						val async = if (method.isAsync) "$ASYNC " else ""
 						val prefix = "${getMemberBase(method.isStatic)}$async${commonAccessBase(nativeMemberName, field = false)}"
 						val rbody = if (method.body != null) method.body else if (method.bodyRef != null) program[method.bodyRef!!]?.body else null
 
@@ -531,12 +552,12 @@ class JsGenerator(injector: Injector) : CommonGenerator(injector) {
 	// @TODO: async/await
 	override fun genStmMonitorEnter(stm: AstStm.MONITOR_ENTER) = indent {
 		ensureAsynchronous("monitorEnter")
-		line("(await(N.monitorEnter(_jc, ${stm.expr.genExpr()})));")
+		line("($AWAIT(N.monitorEnter($JC_COMMA${stm.expr.genExpr()})));")
 	}
 
 	override fun genStmMonitorExit(stm: AstStm.MONITOR_EXIT) = indent {
 		ensureAsynchronous("monitorExit")
-		line("(await(N.monitorExit(_jc, ${stm.expr.genExpr()})));")
+		line("($AWAIT(N.monitorExit($JC_COMMA${stm.expr.genExpr()})));")
 	}
 
 }

--- a/jtransc-gen-js/test/com/jtransc/gen/js/JsTest.kt
+++ b/jtransc-gen-js/test/com/jtransc/gen/js/JsTest.kt
@@ -64,6 +64,9 @@ class JsTest : _Base() {
 	//override val TREESHAKING_TRACE = true
 
 	@Test fun testBigWithoutTreeShaking() = testClass(Params(clazz = BigTest::class.java, minimize = false, log = false, treeShaking = false))
+
+	@Test fun testBigWithoutTreeShakingAndAsync() = testClass(Params(clazz = BigTest::class.java, minimize = false, log = false, treeShaking = false, extra = mapOf("js_enable_async" to "true")))
+
 	@Test fun testBig() = testClass(Params(clazz = BigTest::class.java, minimize = false, log = false))
 	@Test fun testBigMin() = testClass(Params(clazz = BigTest::class.java, minimize = true, log = false))
 	//@Test fun testBigIO() = testClass(Params(clazz = BigIOTest::class.java, minimize = true, log = false, treeShaking = true))
@@ -245,7 +248,7 @@ class JsTest : _Base() {
 	// You can transform output using a ES6->ES5 transpiler
 	@Test fun testSleep() = testClass(Params(clazz = SleepTest::class.java, minimize = false, log = false, debug = true))
 
-	@Test fun testThreadTest() = testClass(Params(clazz = ThreadTest::class.java, minimize = false, log = false, debug = false))
+	@Test fun testThreadTest() = testClass(Params(clazz = ThreadTest::class.java, minimize = false, log = false, debug = false, extra = mapOf("js_enable_async" to "true")))
 
 	@Test fun testMisc2() = testClass(Params(clazz = Misc2Test::class.java, minimize = false, log = false))
 }

--- a/jtransc-gen-js/test/com/jtransc/gen/js/JsTest.kt
+++ b/jtransc-gen-js/test/com/jtransc/gen/js/JsTest.kt
@@ -100,8 +100,8 @@ class JsTest : _Base() {
 
 	@Test fun testURLEncoderDecoder() = testClass(Params(clazz = URLEncoderDecoderTest::class.java, minimize = false, log = false, treeShaking = true))
 
-	//@Test fun testIssue100Double() = testClass<Issue100Double>(minimize = true, log = true, treeShaking = true, debug = true)
-	@Test fun testIssue100Double() = testClass(Params(clazz = Issue100Double::class.java, minimize = true, log = false, treeShaking = true))
+	//@Test fun testIssue100Double() = testClass(Params(clazz = Issue100Double::class.java, minimize = true, log = false, treeShaking = true))
+	@Test fun testIssue100Double() = testClass(Params(clazz = Issue100Double::class.java, minimize = false, log = false, treeShaking = true))
 
 	//@Ignore
 	@Test fun testIssue105() = testClass(Params(clazz = Issue105::class.java, minimize = false, log = false, treeShaking = true))
@@ -176,11 +176,17 @@ class JsTest : _Base() {
 		Shutdown hook!
 	""", Params(clazz = JTranscJsNativeMixedTest::class.java, minimize = false, treeShaking = true))
 
+	//@Test fun referencesTest() = testNativeClass("""
+	//	MethodBodyReferencesTestJs:true
+	//	MethodBodyReferencesTestCpp:false
+	//	MethodBodyReferencesTestJvm:false
+	//""", Params(clazz = MethodBodyReferencesTest::class.java, minimize = true, treeShaking = false))
+
 	@Test fun referencesTest() = testNativeClass("""
 		MethodBodyReferencesTestJs:true
 		MethodBodyReferencesTestCpp:false
 		MethodBodyReferencesTestJvm:false
-	""", Params(clazz = MethodBodyReferencesTest::class.java, minimize = true, treeShaking = false))
+	""", Params(clazz = MethodBodyReferencesTest::class.java, minimize = false, treeShaking = false))
 
 	@Test fun extraKeywordsJs() = testNativeClass("""
 		1

--- a/jtransc-rt-core/src/com/jtransc/JTranscWrapped.java
+++ b/jtransc-rt-core/src/com/jtransc/JTranscWrapped.java
@@ -32,7 +32,7 @@ public class JTranscWrapped {
 
 	//@HaxeMethodBody("return N.box(Reflect.field(this._wrapped, p0._str));")
 	@HaxeMethodBody("return N.box(Reflect.getProperty(this._wrapped, p0._str));")
-	@JTranscMethodBody(target = "js", value = "return N.box(_jc, this._wrapped[N.istr(p0)]);")
+	@JTranscMethodBody(target = "js", value = "return N.box({{ JC_COMMA }}this._wrapped[N.istr(p0)]);")
 	@JTranscSync
 	public Object get(String field) {
 		try {
@@ -58,7 +58,7 @@ public class JTranscWrapped {
 	//public native Object access(String field);
 
 	@HaxeMethodBody("return N.box(Reflect.callMethod(_wrapped, Reflect.field(_wrapped, N.toNativeString(p0)), N.toNativeUnboxedArray(p1)));")
-	@JTranscMethodBody(target = "js", value = "return N.box(_jc, this._wrapped[N.istr(p0)].apply(this._wrapped, N.unboxArray(p1.data)));")
+	@JTranscMethodBody(target = "js", value = "return N.box({{ JC_COMMA }}this._wrapped[N.istr(p0)].apply(this._wrapped, N.unboxArray(p1.data)));")
 	@JTranscAsync
 	public native Object invoke(String name, Object... args);
 

--- a/jtransc-rt-core/src/com/jtransc/io/JTranscConsole.java
+++ b/jtransc-rt-core/src/com/jtransc/io/JTranscConsole.java
@@ -43,7 +43,7 @@ public class JTranscConsole {
 	//@HaxeMethodBody("_log(p0);")
 	//@JTranscMethodBodyList({
 	//	@JTranscMethodBody(target = "php", value = "echo ($p0 !== null) ? \"$p0\" : 'null', \"\\n\";"),
-	//	@JTranscMethodBody(target = "js", value = "console.log(await N.asyncAsyncStr(_jc, p0));"),
+	//	@JTranscMethodBody(target = "js", value = "console.log({{ AWAIT }} N.asyncAsyncStr({{ JC_COMMA }}p0));"),
 	//	@JTranscMethodBody(target = "cpp", value = "N::log(p0 ? p0->{% METHOD java.lang.Object:toString %}() : N::str(std::wstring(L\"null\")));"),
 	//	@JTranscMethodBody(target = "d", value = "writefln(\"%s\", p0); std.stdio.stdout.flush();"),
 	//	@JTranscMethodBody(target = "cs", value = "Console.WriteLine((p0 != null) ? p0.ToString() : \"null\");"),
@@ -72,7 +72,7 @@ public class JTranscConsole {
 	@HaxeMethodBody("_log(p0);")
 	@JTranscMethodBodyList({
 		@JTranscMethodBody(target = "php", value = "echo ($p0 ? 'true' : 'false') . \"\\n\";"),
-		@JTranscMethodBody(target = "js", value = "console.log(await N.asyncAsyncStr(_jc, p0));"),
+		@JTranscMethodBody(target = "js", value = "console.log({{ AWAIT }} N.asyncAsyncStr({{ JC_COMMA }}p0));"),
 		@JTranscMethodBody(target = "cpp", value = "N::log(p0 ? L\"true\" : L\"false\");"),
 		@JTranscMethodBody(target = "d", value = "writefln(\"%s\", p0); std.stdio.stdout.flush();"),
 		@JTranscMethodBody(target = "as3", value = "trace(p0);"),
@@ -85,7 +85,7 @@ public class JTranscConsole {
 	@HaxeMethodBody("_log(p0);")
 	@JTranscMethodBodyList({
 		@JTranscMethodBody(target = "php", value = "echo \"$p0\\n\";"),
-		@JTranscMethodBody(target = "js", value = "console.log(await N.asyncAsyncStr(_jc, p0));"),
+		@JTranscMethodBody(target = "js", value = "console.log({{ AWAIT }} N.asyncAsyncStr({{ JC_COMMA }}p0));"),
 		@JTranscMethodBody(target = "cpp", value = "wprintf(L\"%d\\n\", (int32_t)p0); fflush(stdout);"),
 		@JTranscMethodBody(target = "d", value = "writefln(\"%s\", p0); std.stdio.stdout.flush();"),
 		@JTranscMethodBody(target = "cs", value = "Console.WriteLine(p0);"),
@@ -99,7 +99,7 @@ public class JTranscConsole {
 	@HaxeMethodBody("_log(p0);")
 	@JTranscMethodBodyList({
 		@JTranscMethodBody(target = "php", value = "echo \"$p0\\n\";"),
-		@JTranscMethodBody(target = "js", value = "console.log(await N.asyncAsyncStr(_jc, p0));"),
+		@JTranscMethodBody(target = "js", value = "console.log({{ AWAIT }} N.asyncAsyncStr({{ JC_COMMA }}p0));"),
 		@JTranscMethodBody(target = "cpp", value = "wprintf(L\"%d\\n\", (int32_t)p0); fflush(stdout);"),
 		@JTranscMethodBody(target = "d", value = "writefln(\"%s\", p0); std.stdio.stdout.flush();"),
 		@JTranscMethodBody(target = "cs", value = "Console.WriteLine(p0);"),
@@ -127,7 +127,7 @@ public class JTranscConsole {
 	@HaxeMethodBody("_log(p0);")
 	@JTranscMethodBodyList({
 		@JTranscMethodBody(target = "php", value = "echo \"$p0\\n\";"),
-		@JTranscMethodBody(target = "js", value = "console.log(await N.asyncAsyncStr(_jc, p0));"),
+		@JTranscMethodBody(target = "js", value = "console.log({{ AWAIT }} N.asyncAsyncStr({{ JC_COMMA }}p0));"),
 		@JTranscMethodBody(target = "cpp", value = "wprintf(L\"%d\\n\", (int32_t)p0); fflush(stdout);"),
 		@JTranscMethodBody(target = "d", value = "writefln(\"%d\", p0); std.stdio.stdout.flush();"),
 		@JTranscMethodBody(target = "cs", value = "Console.WriteLine(p0);"),
@@ -155,7 +155,7 @@ public class JTranscConsole {
 	@HaxeMethodBody("_log(p0);")
 	@JTranscMethodBodyList({
 		@JTranscMethodBody(target = "php", value = "echo \"$p0\\n\";"),
-		@JTranscMethodBody(target = "js", value = "console.log(await N.asyncAsyncStr(_jc, p0));"),
+		@JTranscMethodBody(target = "js", value = "console.log({{ AWAIT }} N.asyncAsyncStr({{ JC_COMMA }}p0));"),
 		@JTranscMethodBody(target = "cpp", value = "wprintf(L\"%f\\n\", (float32_t)p0); fflush(stdout);"),
 		@JTranscMethodBody(target = "as3", value = "trace(p0);"),
 		@JTranscMethodBody(target = "dart", value = "print(p0);"),
@@ -168,7 +168,7 @@ public class JTranscConsole {
 	@HaxeMethodBody("_log(p0);")
 	@JTranscMethodBodyList({
 		@JTranscMethodBody(target = "php", value = "echo \"$p0\\n\";"),
-		@JTranscMethodBody(target = "js", value = "console.log(await N.asyncAsyncStr(_jc, p0));"),
+		@JTranscMethodBody(target = "js", value = "console.log({{ AWAIT }} N.asyncAsyncStr({{ JC_COMMA }}p0));"),
 		@JTranscMethodBody(target = "cpp", value = "wprintf(L\"%llf\\n\", (float64_t)p0); fflush(stdout);"),
 		@JTranscMethodBody(target = "as3", value = "trace(p0);"),
 		@JTranscMethodBody(target = "dart", value = "print(p0);"),

--- a/jtransc-rt-core/src/com/jtransc/text/JTranscStringTools.java
+++ b/jtransc-rt-core/src/com/jtransc/text/JTranscStringTools.java
@@ -66,7 +66,7 @@ public class JTranscStringTools {
 	@JTranscMethodBodyList({
 		@JTranscMethodBody(target = "php", value  = "return {% SMETHOD java.lang.String:_replace %}(p0, p1, p2);"),
 		@JTranscMethodBody(target = "cpp", value  = "return {% SMETHOD java.lang.String:_replace %}(p0, p1, p2);"),
-		@JTranscMethodBody(target = "js", value   = "return {% SMETHOD java.lang.String:_replace %}(_jc, p0, p1, p2);"),
+		@JTranscMethodBody(target = "js", value   = "return {% SMETHOD java.lang.String:_replace %}({{ JC_COMMA }}p0, p1, p2);"),
 		@JTranscMethodBody(target = "as3", value  = "return {% SMETHOD java.lang.String:_replace %}(p0, p1, p2);"),
 		@JTranscMethodBody(target = "dart", value = "return {% SMETHOD java.lang.String:_replace %}(p0, p1, p2);")
 	})

--- a/jtransc-rt/resources/js/Base.js
+++ b/jtransc-rt/resources/js/Base.js
@@ -80,8 +80,10 @@ String.prototype.quote = String.prototype.quote || (function () { return JSON.st
 
 (function(_global) { "use strict";
 
+
 //const _global = (typeof window !== "undefined") ? window : global;
 const DEBUG_VERSION = {{ debug != false }};
+const IS_ASYNC = {{ !!IS_ASYNC }};
 const onBrowser = typeof window != "undefined";
 const onNodeJs = typeof window == "undefined";
 
@@ -427,23 +429,23 @@ function __createJavaArrayBaseType() {
 			this.desc = desc;
 		}
 
-		getClass(_jc) {
-			return N.resolveClass(_jc, this.desc);
+		getClass({{ JC }}) {
+			return N.resolveClass({{ JC_COMMA }}this.desc);
 		}
 
-		"{% METHOD java.lang.Object:getClass %}"(_jc) {
-			return N.resolveClass(_jc, this.desc);
+		"{% METHOD java.lang.Object:getClass %}"({{ JC }}) {
+			return N.resolveClass({{ JC_COMMA }}this.desc);
 		}
 
 		"{% METHOD java.lang.Object:clone %}"() {
 			return this.clone();
 		}
 
-		"{% METHOD java.lang.Object:getClass %}"(_jc) {
-			return N.resolveClass(_jc, this.desc);
+		"{% METHOD java.lang.Object:getClass %}"({{ JC }}) {
+			return N.resolveClass({{ JC_COMMA }}this.desc);
 		};
 
-		"{% METHOD java.lang.Object:toString %}"(_jc) {
+		"{% METHOD java.lang.Object:toString %}"({{ JC }}) {
 			return N.str('ARRAY(' + this.desc + ')');
 		};
 	}
@@ -696,10 +698,10 @@ var __reints = (function() {
 })();
 
 class N {
-	static async preInit(_jc) {
+	static {{ ASYNC }} preInit({{ JC }}) {
 	}
 
-	static afterInit(_jc) {
+	static afterInit({{ JC }}) {
 		//console.log(JA_Z);
 		//console.log(JA_B);
 		//console.log(JA_C);
@@ -892,24 +894,24 @@ class N {
 		return strs.data.map(function(s) { return N.istr(s); });
 	};
 
-	static async iteratorToArray(_jc, it) {
+	static {{ ASYNC }} iteratorToArray({{ JC_COMMA }}it) {
 		if (it == null) return null;
 		var out = [];
-		while (await it{% IMETHOD java.util.Iterator:hasNext:()Z %}(_jc)) {
-			out.push(await it{% IMETHOD java.util.Iterator:next:()Ljava/lang/Object; %}(_jc));
+		while ({{ AWAIT }} it{% IMETHOD java.util.Iterator:hasNext:()Z %}({{ JC }})) {
+			out.push({{ AWAIT }} it{% IMETHOD java.util.Iterator:next:()Ljava/lang/Object; %}({{ JC }}));
 		}
 		return out;
 	};
 
-	static async imap(_jc, map) {
+	static {{ ASYNC }} imap({{ JC_COMMA }}map) {
 		if (map == null) return null;
 		var obj = {};
-		let array = await(N.iteratorToArray(_jc, await await map{% IMETHOD java.util.Map:entrySet %}(){% IMETHOD java.util.Set:iterator %}(_jc)))
+		let array = {{ AWAIT }}(N.iteratorToArray({{ JC_COMMA }}{{ AWAIT }} {{ AWAIT }} map{% IMETHOD java.util.Map:entrySet %}(){% IMETHOD java.util.Set:iterator %}({{ JC }})))
 
 		for (let n = 0; n < array.length; n++) {
 			let item = array[n];
-			var key = await item{% IMETHOD java.util.Map$Entry:getKey %}(_jc);
-			var value = await item{% IMETHOD java.util.Map$Entry:getValue %}(_jc);
+			var key = {{ AWAIT }} item{% IMETHOD java.util.Map$Entry:getKey %}({{ JC }});
+			var value = {{ AWAIT }} item{% IMETHOD java.util.Map$Entry:getValue %}({{ JC }});
 			obj[N.unbox(key)] = N.unbox(value);
 		}
 		return obj;
@@ -946,8 +948,8 @@ class N {
 	};
 
 	// @TODO: Make this sync
-	static resolveClass(_jc, name) {
-		return {% SMETHOD java.lang.Class:forName:(Ljava/lang/String;)Ljava/lang/Class; %}(_jc, N.str(name));
+	static resolveClass({{ JC_COMMA }}name) {
+		return {% SMETHOD java.lang.Class:forName:(Ljava/lang/String;)Ljava/lang/Class; %}({{ JC_COMMA }}N.str(name));
 	};
 
 	static createStackTraceElement(declaringClass, methodName, fileName, lineNumber) {
@@ -1001,17 +1003,17 @@ class N {
 		for (var n = 0; n < array.length; ++n) array.set(n, buf[n]);
 	};
 
-	static boxVoid    (_jc, value) { return null; }
-	static boxBool    (_jc, value) { return {% SMETHOD java.lang.Boolean:valueOf:(Z)Ljava/lang/Boolean; %}(_jc, value); }
-	static boxByte    (_jc, value) { return {% SMETHOD java.lang.Byte:valueOf:(B)Ljava/lang/Byte; %}(_jc, value); }
-	static boxShort   (_jc, value) { return {% SMETHOD java.lang.Short:valueOf:(S)Ljava/lang/Short; %}(_jc, value); }
-	static boxChar    (_jc, value) { return {% SMETHOD java.lang.Character:valueOf:(C)Ljava/lang/Character; %}(_jc, value); }
-	static boxInt     (_jc, value) { return {% SMETHOD java.lang.Integer:valueOf:(I)Ljava/lang/Integer; %}(_jc, value); }
-	static boxLong    (_jc, value) { return {% SMETHOD java.lang.Long:valueOf:(J)Ljava/lang/Long; %}(_jc, value); }
-	static boxFloat   (_jc, value) { return {% SMETHOD java.lang.Float:valueOf:(F)Ljava/lang/Float; %}(_jc, value); }
-	static boxDouble  (_jc, value) { return {% SMETHOD java.lang.Double:valueOf:(D)Ljava/lang/Double; %}(_jc, value); }
-	static boxString  (_jc, value) { return (value != null) ? N.str(value) : null; }
-	static boxWrapped (_jc, value) { return N.wrap(value); }
+	static boxVoid    ({{ JC_COMMA }}value) { return null; }
+	static boxBool    ({{ JC_COMMA }}value) { return {% SMETHOD java.lang.Boolean:valueOf:(Z)Ljava/lang/Boolean; %}({{ JC_COMMA }}value); }
+	static boxByte    ({{ JC_COMMA }}value) { return {% SMETHOD java.lang.Byte:valueOf:(B)Ljava/lang/Byte; %}({{ JC_COMMA }}value); }
+	static boxShort   ({{ JC_COMMA }}value) { return {% SMETHOD java.lang.Short:valueOf:(S)Ljava/lang/Short; %}({{ JC_COMMA }}value); }
+	static boxChar    ({{ JC_COMMA }}value) { return {% SMETHOD java.lang.Character:valueOf:(C)Ljava/lang/Character; %}({{ JC_COMMA }}value); }
+	static boxInt     ({{ JC_COMMA }}value) { return {% SMETHOD java.lang.Integer:valueOf:(I)Ljava/lang/Integer; %}({{ JC_COMMA }}value); }
+	static boxLong    ({{ JC_COMMA }}value) { return {% SMETHOD java.lang.Long:valueOf:(J)Ljava/lang/Long; %}({{ JC_COMMA }}value); }
+	static boxFloat   ({{ JC_COMMA }}value) { return {% SMETHOD java.lang.Float:valueOf:(F)Ljava/lang/Float; %}({{ JC_COMMA }}value); }
+	static boxDouble  ({{ JC_COMMA }}value) { return {% SMETHOD java.lang.Double:valueOf:(D)Ljava/lang/Double; %}({{ JC_COMMA }}value); }
+	static boxString  ({{ JC_COMMA }}value) { return (value != null) ? N.str(value) : null; }
+	static boxWrapped ({{ JC_COMMA }}value) { return N.wrap(value); }
 
 	static unboxVoid      (value) { return null; }
 	static unboxBool      (value) { return value["{% FIELD java.lang.Boolean:value:Z %}"]; }
@@ -1051,8 +1053,8 @@ class N {
 		return out;
 	}
 
-	static createRuntimeException(_jc, msg) {
-		return {% CONSTRUCTOR java.lang.RuntimeException:(Ljava/lang/String;)V %}(_jc, N.str(msg));
+	static createRuntimeException({{ JC_COMMA }}msg) {
+		return {% CONSTRUCTOR java.lang.RuntimeException:(Ljava/lang/String;)V %}({{ JC_COMMA }}N.str(msg));
 	};
 
 	static throwRuntimeException(msg) {
@@ -1109,38 +1111,40 @@ class N {
 		return JA_L.fromArray(array.map(function(it) { return N.box(it); }));
 	};
 
-	static box(_jc, v) {
+	static box({{ JC_COMMA }}v) {
 		if (v instanceof {% CLASS java.lang.Object %}) return v; // already boxed!
-		if (v instanceof Int64) return N.boxLong(_jc, v);
+		if (v instanceof Int64) return N.boxLong({{ JC_COMMA }}v);
 		if (typeof v == 'string') return N.str(v);
-		if ((v|0) == v) return N.boxInt(_jc, v);
-		if (+(v) == v) return N.boxFloat(_jc, v);
+		if ((v|0) == v) return N.boxInt({{ JC_COMMA }}v);
+		if (+(v) == v) return N.boxFloat({{ JC_COMMA }}v);
 		if ((v == null) || N.is(v, {% CLASS java.lang.Object %})) return v;
 		return N.wrap(v);
 	};
 
 	static isNegativeZero(x) { return x === 0 && 1 / x === -Infinity; };
 
-	//N.sort = async function(array, start, end, comparator) {
+	//N.sort = {{ ASYNC }} function(array, start, end, comparator) {
 	//	var slice = array.slice(start, end);
 	//	if (comparator === undefined) {
 	//		slice.sort();
 	//	} else {
 	//		throw 'Unsupported N.sort!';
-	//		//slice.sort(async function(a, b) {
-	//		//	return await comparator["{% METHOD java.util.Comparator:compare:(Ljava/lang/Object;Ljava/lang/Object;)I %}"](a, b);
+	//		//slice.sort({{ ASYNC }} function(a, b) {
+	//		//	return {{ AWAIT }} comparator["{% METHOD java.util.Comparator:compare:(Ljava/lang/Object;Ljava/lang/Object;)I %}"](a, b);
 	//		//});
 	//	}
 	//	for (var n = 0; n < slice.length; ++n) array[start + n] = slice[n];
 	//};
 
-	static async asyncAsyncStr(_jc, v) {
+	static {{ ASYNC }} asyncAsyncStr({{ JC_COMMA }}v) {
 		if (v == null) return 'null';
+		{% if IS_ASYNC %}
 		if (typeof v.toStringAsync !== 'undefined') {
-			return N.istr(await(v.toStringAsync(_jc)));
+			return N.istr({{ AWAIT }}(v.toStringAsync({{ JC }})));
 		}
+		{% end %}
 		return '' + v;
-	};
+	}
 
 	static getByteArray(v) {
 		if (v instanceof JA_B) return v;
@@ -1171,28 +1175,37 @@ class N {
     static get doubleToLongBits() { return __reints.doubleToLongBits; }
     static get longBitsToDouble() { return __reints.longBitsToDouble; }
 
-    // @TODO: async
-    static async monitorEnter(_jc, obj) {
-    	await(RecursiveMutex.getMutex(obj).lock(_jc));
-    }
+    // @TODO: {{ ASYNC }}
+   	{% if IS_JC %}
+		static {{ ASYNC }} monitorEnter({{ JC_COMMA }}obj) {
+			{{ AWAIT }}(RecursiveMutex.getMutex(obj).lock({{ JC }}));
+		}
 
-    static async monitorExit(_jc, obj) {
-    	await(RecursiveMutex.getMutex(obj).unlock(_jc));
-    }
+		static {{ ASYNC }} monitorExit({{ JC_COMMA }}obj) {
+			{{ AWAIT }}(RecursiveMutex.getMutex(obj).unlock({{ JC }}));
+		}
 
-    static async threadNotify(_jc, obj) {
-    	await(RecursiveMutex.getMutex(obj).notify(_jc));
-    }
+		static {{ ASYNC }} threadNotify({{ JC_COMMA }}obj) {
+			{{ AWAIT }}(RecursiveMutex.getMutex(obj).notify({{ JC }}));
+		}
 
-    static async threadNotifyAll(_jc, obj) {
-    	await(RecursiveMutex.getMutex(obj).notifyAll(_jc));
-    }
+		static {{ ASYNC }} threadNotifyAll({{ JC_COMMA }}obj) {
+			{{ AWAIT }}(RecursiveMutex.getMutex(obj).notifyAll({{ JC }}));
+		}
 
-    static async threadWait(_jc, obj, timeoutMs, timeoutNanos) {
-    	await(RecursiveMutex.getMutex(obj).wait(_jc, timeoutMs, timeoutNanos));
-    }
+		static {{ ASYNC }} threadWait({{ JC_COMMA }}obj, timeoutMs, timeoutNanos) {
+			{{ AWAIT }}(RecursiveMutex.getMutex(obj).wait({{ JC_COMMA }}timeoutMs, timeoutNanos));
+		}
+	{% else %}
+		static {{ ASYNC }} monitorEnter({{ JC_COMMA }}obj) { }
+		static {{ ASYNC }} monitorExit({{ JC_COMMA }}obj) { }
+		static {{ ASYNC }} threadNotify({{ JC_COMMA }}obj) { throw new Error('Not implemented N.threadNotify'); }
+		static {{ ASYNC }} threadNotifyAll({{ JC_COMMA }}obj) { throw new Error('Not implemented N.threadNotifyAll'); }
+		static {{ ASYNC }} threadWait({{ JC_COMMA }}obj, timeoutMs, timeoutNanos) { throw new Error('Not implemented N.threadWait'); }
+	{% end %}
 } // N
 
+{% if IS_JC %}
 class RecursiveMutex {
 	static getMutex(obj) {
     	if (obj.__jt_mutex__ == null) obj.__jt_mutex__ = new RecursiveMutex();
@@ -1208,9 +1221,9 @@ class RecursiveMutex {
 
 	// MUTEX
 
-	async lock(_jc) {
-    	//console.log('RecursiveMutex.lock:', this, _jc);
-		let threadId = _jc.threadId;
+	{{ ASYNC }} lock({{ JC }}) {
+    	//console.log('RecursiveMutex.lock:', this, {{ JC }});
+		let threadId = {{ JC }}.threadId;
 		if (this.capturedThread == -1) this.capturedThread = threadId;
 
 		if (this.capturedThread == threadId) {
@@ -1226,9 +1239,9 @@ class RecursiveMutex {
 		}
 	}
 
-	async unlock(_jc) {
-    	//console.log('RecursiveMutex.unlock:', this, _jc);
-		let threadId = _jc.threadId;
+	{{ ASYNC }} unlock({{ JC }}) {
+    	//console.log('RecursiveMutex.unlock:', this, {{ JC }});
+		let threadId = {{ JC }}.threadId;
 
 		if (this.capturedThread == threadId) {
 			this.capturedCount--;
@@ -1250,22 +1263,22 @@ class RecursiveMutex {
 
 	// WAIT/NOTIFY
 
-	async notify(_jc) {
-		//console.log('RecursiveMutex.notify', _jc);
+	{{ ASYNC }} notify({{ JC }}) {
+		//console.log('RecursiveMutex.notify', {{ JC }});
 		if (this.waitQueue.length > 0) {
 			let callback = this.waitQueue.shift();
 			callback();
 		}
 	}
 
-	async notifyAll(_jc) {
-		//console.log('RecursiveMutex.notifyAll', _jc);
+	{{ ASYNC }} notifyAll({{ JC }}) {
+		//console.log('RecursiveMutex.notifyAll', {{ JC }});
 		var queue = this.waitQueue.splice(0, this.waitQueue.length);
 		for (let callback of queue) callback();
 	}
 
-	async wait(_jc, timeoutMs, timeoutNano) {
-		//console.log('RecursiveMutex.wait', _jc, timeoutMs, timeoutNano);
+	{{ ASYNC }} wait({{ JC_COMMA }}timeoutMs, timeoutNano) {
+		//console.log('RecursiveMutex.wait', {{ JC_COMMA }}timeoutMs, timeoutNano);
 		return new Promise((resolve, reject) => {
 			let func;
 			let timer = -1;
@@ -1291,6 +1304,7 @@ class RecursiveMutex {
 		});
 	}
 }
+{% end %}
 
 function stackTrace() {
 	var err = new Error();
@@ -1302,17 +1316,23 @@ class java_lang_Object_base {
 	}
 
 	toString() {
-		console.error('unsupported use toStringAsync instead:');
-		console.error((new Error()).stack);
-		return '(' + this.constructor.name + '): unsupported use toStringAsync instead';
+		{% if IS_ASYNC %}
+			console.error('unsupported use toStringAsync instead:');
+			console.error((new Error()).stack);
+			return '(' + this.constructor.name + '): unsupported use toStringAsync instead';
+		{% else %}
+			return this ? N.istr(this{% IMETHOD java.lang.Object:toString %}({{ JC }})) : null;
+		{% end %}
 	}
 
-	async toStringAsync(_jc) {
-		return this ? N.istr(await this{% IMETHOD java.lang.Object:toString %}(_jc)) : null;
+	{{ ASYNC }} toStringAsync({{ JC }}) {
+		return this ? N.istr({{ AWAIT }} this{% IMETHOD java.lang.Object:toString %}({{ JC }})) : null;
 	};
 }
 
+{% if IS_JC %}
 java_lang_Object_base.prototype.__jt_mutex__ = null;
+{% end %}
 java_lang_Object_base.prototype.___id = 0;
 java_lang_Object_base.prototype.__JT__CLASS_ID = java_lang_Object_base.__JT__CLASS_ID = 0;
 java_lang_Object_base.prototype.__JT__CLASS_IDS = java_lang_Object_base.__JT__CLASS_IDS = [0];

--- a/jtransc-rt/src/com/jtransc/mix/JTranscProcessMulti.java
+++ b/jtransc-rt/src/com/jtransc/mix/JTranscProcessMulti.java
@@ -41,7 +41,7 @@ public class JTranscProcessMulti extends JTranscProcess {
 		@HaxeMethodBody("return null;"),
 	})
 	@JTranscMethodBody(target = "js", value = {
-		"return N.wrap(require('child_process').spawnSync(N.istr(p0), N.istrArray(p1), { cwd : N.istr(p2), env : await(N.imap(p3)) }));"
+		"return N.wrap(require('child_process').spawnSync(N.istr(p0), N.istrArray(p1), { cwd : N.istr(p2), env : {{ AWAIT }}(N.imap(p3)) }));"
 	}, async = true)
 	private native JTranscWrapped create(String cmd, String[] args, String cwd, Map<String, String> env);
 

--- a/jtransc-rt/src/java/lang/Object.java
+++ b/jtransc-rt/src/java/lang/Object.java
@@ -149,7 +149,7 @@ public class Object {
 		wait(0L, 0);
 	}
 
-	@JTranscMethodBody(target = "js", value = "await N.threadWait(_jc, this, N.j2d(p0), p1);", async = true)
+	@JTranscMethodBody(target = "js", value = "{{ AWAIT }} N.threadWait({{ JC_COMMA }}this, N.j2d(p0), p1);", async = true)
 	@JTranscAsync
 	public final void wait(long timeout, int nanos) throws InterruptedException {
 		if (timeout < 0)
@@ -161,13 +161,13 @@ public class Object {
 		}
 	}
 
-	@JTranscMethodBody(target = "js", value = "await N.threadNotify(_jc, this);", async = true)
+	@JTranscMethodBody(target = "js", value = "{{ AWAIT }} N.threadNotify({{ JC_COMMA }}this);", async = true)
 	@JTranscAsync
 	public final void notify() {
 		waitTimeout = 0;
 	}
 
-	@JTranscMethodBody(target = "js", value = "await N.threadNotifyAll(_jc, this);", async = true)
+	@JTranscMethodBody(target = "js", value = "{{ AWAIT }} N.threadNotifyAll({{ JC_COMMA }}this);", async = true)
 	@JTranscAsync
 	public final void notifyAll() {
 		waitTimeout = 0;

--- a/jtransc-rt/src/java/lang/Runtime.java
+++ b/jtransc-rt/src/java/lang/Runtime.java
@@ -64,7 +64,7 @@ public class Runtime {
 		}
 	}
 
-	@JTranscMethodBody(target = "js", value = "var that = this; process.on('exit', function() { that{% IMETHOD java.lang.Runtime:_executeShutdownHooks %}(_jc); });")
+	@JTranscMethodBody(target = "js", value = "var that = this; process.on('exit', function() { that{% IMETHOD java.lang.Runtime:_executeShutdownHooks %}({{ JC }}); });")
 	private void _registerShutdownHook() {
 	}
 

--- a/jtransc-rt/src/java/lang/Thread.java
+++ b/jtransc-rt/src/java/lang/Thread.java
@@ -64,7 +64,9 @@ public class Thread implements Runnable {
 	@JTranscMethodBody(target = "cpp", cond = "USE_BOOST", value = "return _cpp_threads[boost::this_thread::get_id()];")
 	@JTranscMethodBody(target = "cpp", value = "return _cpp_threads[std::this_thread::get_id()];")
 	@HaxeMethodBody(target = "cpp", value = "return threadsMap.get(cpp.vm.Thread.current().handle);")
-	@JTranscMethodBody(target = "js", value = "return {% SMETHOD #CLASS:getThreadById %}(_jc, _jc.threadId);")
+	@JTranscMethodBody(target = "js", value = {
+		"{% if IS_JC %}return {% SMETHOD #CLASS:getThreadById %}({{ JC_COMMA }}_jc.threadId);{% else %}return {% SMETHOD #CLASS:getDefaultThread %}();{% end %}"
+	})
 	private static Thread _getCurrentThreadOrNull() {
 		for (Thread t : getThreadsCopy()) return t; // Just valid for programs with just once thread
 		return null;
@@ -73,6 +75,11 @@ public class Thread implements Runnable {
 	private static Thread getThreadById(int id) {
 		//JTranscConsole.log("getThreadById: " + id);
 		return _threadsById.get((long)id);
+	}
+
+	private static Thread getDefaultThread() {
+		lazyPrepareThread();
+		return _mainThread;
 	}
 
 	public StackTraceElement[] getStackTrace() {
@@ -93,7 +100,12 @@ public class Thread implements Runnable {
 	@JTranscMethodBody(target = "d", value = "Thread.sleep(dur!(\"msecs\")(p0));")
 	@JTranscMethodBody(target = "cpp", cond = "USE_BOOST", value = "boost::this_thread::sleep_for(boost::chrono::milliseconds(p0));")
 	@JTranscMethodBody(target = "cpp", value = "std::this_thread::sleep_for(std::chrono::milliseconds(p0));")
-	@JTranscMethodBody(target = "js", value = "return new Promise((resolve, reject) => { setTimeout(resolve, p0); });", async = true)
+	//@JTranscMethodBody(target = "js", value = {
+	//	"{% if IS_ASYNC %}return new Promise((resolve, reject) => { setTimeout(resolve, p0); });" +
+	//	"{% else %}return {% SMETHOD com.jtransc.JTranscSystem:sleep %}(p0);" +
+	//	"{% end %}"
+	//}, async = true)
+	@JTranscMethodBody(target = "js", cond = "IS_ASYNC", value = "return new Promise((resolve, reject) => { setTimeout(resolve, p0); });", async = true)
 	public static void sleep(long millis) throws InterruptedException {
 		JTranscSystem.sleep(millis);
 	}
@@ -217,7 +229,9 @@ public class Thread implements Runnable {
 		"	that{% IMETHOD java.lang.Thread:runInternal:()V %}();" +
 		"});"
 	)
-	@JTranscMethodBody(target = "js", value = "this{% IMETHOD java.lang.Thread:runInternal:()V %}({ threadId: p0, global: _jc.global });") // NOTE: await missing intentionally
+	@JTranscMethodBody(target = "js", value = {
+		"{% if IS_JC %}this{% IMETHOD java.lang.Thread:runInternal:()V %}({ threadId: p0, global: _jc.global });{% else %}this{% IMETHOD java.lang.Thread:runInternal:()V %}();{% end %}"
+	}) // NOTE: await missing intentionally
 	@JTranscAsync
 	private void _start(@SuppressWarnings("unused") int threadId) {
 		System.err.println("WARNING: Threads not supported! Executing thread code in the parent's thread!");

--- a/jtransc-rt/src/java/nio/channels/AsynchronousServerSocketChannel.java
+++ b/jtransc-rt/src/java/nio/channels/AsynchronousServerSocketChannel.java
@@ -64,7 +64,7 @@ public class AsynchronousServerSocketChannel implements AsynchronousChannel, Net
 		"var net = require('net');",
 		"var _this = this;",
 		"this.server = net.createServer(function(socket) {",
-		"	var client = {% CONSTRUCTOR java.nio.channels.AsynchronousSocketChannel:()V %}(_jc);",
+		"	var client = {% CONSTRUCTOR java.nio.channels.AsynchronousSocketChannel:()V %}({{ JC }});",
 		"	client.client = socket;",
 		"	_this.clients.push(client);",
 		"	if (_this.handlers.length != 0) { _this.handlers.shift()(_this.clients.shift()); }",
@@ -99,7 +99,7 @@ public class AsynchronousServerSocketChannel implements AsynchronousChannel, Net
 	@JTranscMethodBody(target = "js", value = {
 		"var attachment = p0, handler = p1;",
 		"var handlers = this.handlers;",
-		"function fhandle(client) { handler{% IMETHOD java.nio.channels.CompletionHandler:completed %}(_jc, client, attachment); }",
+		"function fhandle(client) { handler{% IMETHOD java.nio.channels.CompletionHandler:completed %}({{ JC_COMMA }}client, attachment); }",
 		"if (this.clients.length != 0) { fhandle(this.clients.shift()); } else { this.handlers.push(fhandle); }"
 	})
 	public native <A> void accept(A attachment, CompletionHandler<AsynchronousSocketChannel, ? super A> handler);

--- a/jtransc-rt/src/java/nio/channels/AsynchronousSocketChannel.java
+++ b/jtransc-rt/src/java/nio/channels/AsynchronousSocketChannel.java
@@ -71,10 +71,10 @@ public class AsynchronousSocketChannel implements AsynchronousByteChannel, Netwo
 		"var net = require('net');",
 		"this.client = new net.Socket();",
 		"this.client.on('error', function() {",
-		"	handler{% IMETHOD java.nio.channels.CompletionHandler:failed %}(_jc, N.createRuntimeException(_jc, 'error'), attachment);",
+		"	handler{% IMETHOD java.nio.channels.CompletionHandler:failed %}({{ JC_COMMA }}N.createRuntimeException({{ JC_COMMA }}'error'), attachment);",
 		"});",
 		"this.client.connect(port, address, function() {",
-		"	handler{% IMETHOD java.nio.channels.CompletionHandler:completed %}(_jc, null, attachment);",
+		"	handler{% IMETHOD java.nio.channels.CompletionHandler:completed %}({{ JC_COMMA }}null, attachment);",
 		"});",
 	})
 	native private <A> void _connect(String address, int port, A attachment, CompletionHandler<Void, ? super A> handler);
@@ -99,7 +99,7 @@ public class AsynchronousSocketChannel implements AsynchronousByteChannel, Netwo
 	@JTranscMethodBody(target = "js", value = {
 		"var data = p0.data, offset = p1, len = p2, timeout = p3, attachment = p4, handler = p5;",
 		"this.client.write(new Buffer(new Int8Array(data.buffer, offset, len)), function() {",
-		"	handler{% IMETHOD java.nio.channels.CompletionHandler:completed %}(_jc, N.boxInt(len), attachment);",
+		"	handler{% IMETHOD java.nio.channels.CompletionHandler:completed %}({{ JC_COMMA }}N.boxInt(len), attachment);",
 		"});",
 	})
 	native private <A> void _write(byte[] data, int offset, int len, double timeout, A attachment, CompletionHandler<Integer, ? super A> handler);

--- a/jtransc-rt/src/javax/script/jtransc/impl/JSJtranscScriptEngine.java
+++ b/jtransc-rt/src/javax/script/jtransc/impl/JSJtranscScriptEngine.java
@@ -27,7 +27,7 @@ public class JSJtranscScriptEngine extends JTranscScriptEngine {
 	@JTranscMethodBody(target = "js", value = {
 		//"console.log(N.istr(p0));",
 		"var print = console.log; var result = eval(N.istr(p0));",
-		"return N.box(_jc, result);",
+		"return N.box({{ JC_COMMA }}result);",
 	})
 	native public Object eval(String script, ScriptContext context) throws ScriptException;
 }


### PR DESCRIPTION
Since this affects negatively to performance (specially before detecting synchronous paths is implemented), this should be opt-in.

For example. Benchmark:

```
TOTAL time: 6615.0 <--- without asynchronous
TOTAL time: 30309.0 <--- with asynchronous without optimizations (5x slower)
```